### PR TITLE
Update separator functionality

### DIFF
--- a/systray.go
+++ b/systray.go
@@ -38,6 +38,35 @@ func init() {
 	runtime.LockOSThread()
 }
 
+type Separator struct {
+	// id uniquely identify a separator, not supposed to be modified
+	id uint32
+	// parent menu item
+	parent uint32
+}
+
+func (s *Separator) Hide() {
+	changeSeparatorVisibility(s.id, false)
+}
+
+func (s *Separator) Show() {
+	changeSeparatorVisibility(s.id, true)
+}
+
+func (s *Separator) Remove() {
+	removeSeparator(s.id)
+}
+
+// AddSeparator adds a separator bar to the menu and returns new Separator object
+func AddSeparator() *Separator {
+	id := currentID.Add(1)
+	addSeparator(id, 0)
+	return &Separator{
+		id:     id,
+		parent: 0,
+	}
+}
+
 // MenuItem is used to keep track each menu item of systray.
 // Don't create it directly, use the one systray.AddMenuItem() returned
 type MenuItem struct {
@@ -171,38 +200,14 @@ func AddMenuItemCheckbox(title string, tooltip string, checked bool) *MenuItem {
 	return item
 }
 
-// AddSeparator adds a separator bar to the menu
-func AddSeparator() {
-	addSeparator(currentID.Add(1), 0)
-}
-
-// AddSeparatorID adds a separator bar to the menu and returns its id
-func AddSeparatorID() uint32 {
-	id := currentID.Add(1)
-	addSeparator(id, 0)
-	return id
-}
-
-// HideSeparator hides a separator bar by its id
-func HideSeparator(id uint32) {
-	changeSeparatorVisibility(id, 0, false)
-}
-
-// ShowSeparator shows a separator bar by its id
-func ShowSeparator(id uint32) {
-	changeSeparatorVisibility(id, 0, true)
-}
-
 // AddSeparator adds a separator bar to the submenu
-func (item *MenuItem) AddSeparator() {
-	addSeparator(currentID.Add(1), item.id)
-}
-
-// AddSeparatorID adds a separator bar to the submenu and returns its id
-func (item *MenuItem) AddSeparatorID() uint32 {
+func (item *MenuItem) AddSeparator() *Separator {
 	id := currentID.Add(1)
 	addSeparator(id, item.id)
-	return id
+	return &Separator{
+		id:     id,
+		parent: item.id,
+	}
 }
 
 // AddSubMenuItem adds a nested sub-menu item with the designated title and tooltip.

--- a/systray.go
+++ b/systray.go
@@ -176,9 +176,33 @@ func AddSeparator() {
 	addSeparator(currentID.Add(1), 0)
 }
 
+// AddSeparatorID adds a separator bar to the menu and returns its id
+func AddSeparatorID() uint32 {
+	id := currentID.Add(1)
+	addSeparator(id, 0)
+	return id
+}
+
+// HideSeparator hides a separator bar by its id
+func HideSeparator(id uint32) {
+	hideSeparator(id, 0)
+}
+
+// ShowSeparator shows a separator bar by its id
+func ShowSeparator(id uint32) {
+	showSeparator(id, 0)
+}
+
 // AddSeparator adds a separator bar to the submenu
 func (item *MenuItem) AddSeparator() {
 	addSeparator(currentID.Add(1), item.id)
+}
+
+// AddSeparatorID adds a separator bar to the submenu and returns its id
+func (item *MenuItem) AddSeparatorID() uint32 {
+	id := currentID.Add(1)
+	addSeparator(id, item.id)
+	return id
 }
 
 // AddSubMenuItem adds a nested sub-menu item with the designated title and tooltip.

--- a/systray.go
+++ b/systray.go
@@ -185,12 +185,12 @@ func AddSeparatorID() uint32 {
 
 // HideSeparator hides a separator bar by its id
 func HideSeparator(id uint32) {
-	hideSeparator(id, 0)
+	changeSeparatorVisibility(id, 0, false)
 }
 
 // ShowSeparator shows a separator bar by its id
 func ShowSeparator(id uint32) {
-	showSeparator(id, 0)
+	changeSeparatorVisibility(id, 0, true)
 }
 
 // AddSeparator adds a separator bar to the submenu

--- a/systray_menu_unix.go
+++ b/systray_menu_unix.go
@@ -224,28 +224,14 @@ func addSeparator(id uint32, parent uint32) {
 	refresh()
 }
 
-func hideSeparator(id uint32, parent uint32) {
+func changeSeparatorVisibility(id uint32, parent uint32, visible bool) {
 	instance.menuLock.Lock()
 	defer instance.menuLock.Unlock()
 	menu, _ := findLayout(int32(parent))
 	for _, i := range menu.V2 {
 		item := i.Value().(*menuLayout)
 		if item.V0 == int32(id) {
-			item.V1["visible"] = dbus.MakeVariant(false)
-			refresh()
-			return
-		}
-	}
-}
-
-func showSeparator(id uint32, parent uint32) {
-	instance.menuLock.Lock()
-	defer instance.menuLock.Unlock()
-	menu, _ := findLayout(int32(parent))
-	for _, i := range menu.V2 {
-		item := i.Value().(*menuLayout)
-		if item.V0 == int32(id) {
-			item.V1["visible"] = dbus.MakeVariant(true)
+			item.V1["visible"] = dbus.MakeVariant(visible)
 			refresh()
 			return
 		}

--- a/systray_menu_unix.go
+++ b/systray_menu_unix.go
@@ -224,17 +224,17 @@ func addSeparator(id uint32, parent uint32) {
 	refresh()
 }
 
-func changeSeparatorVisibility(id uint32, parent uint32, visible bool) {
+func changeSeparatorVisibility(id uint32, visible bool) {
 	instance.menuLock.Lock()
 	defer instance.menuLock.Unlock()
-	menu, _ := findLayout(int32(parent))
-	for _, i := range menu.V2 {
-		item := i.Value().(*menuLayout)
-		if item.V0 == int32(id) {
-			item.V1["visible"] = dbus.MakeVariant(visible)
-			refresh()
-			return
-		}
+	item, exist := findLayout(int32(id))
+	if !exist {
+		return
+	}
+	if item.V0 == int32(id) {
+		item.V1["visible"] = dbus.MakeVariant(visible)
+		refresh()
+		return
 	}
 }
 
@@ -312,6 +312,16 @@ func removeMenuItem(item *MenuItem) {
 
 	if items, removed := removeSubLayout(int32(item.id), parent.V2); removed {
 		parent.V2 = items
+		refresh()
+	}
+}
+
+func removeSeparator(id uint32) {
+	instance.menuLock.Lock()
+	defer instance.menuLock.Unlock()
+
+	if items, removed := removeSubLayout(int32(id), instance.menu.V2); removed {
+		instance.menu.V2 = items
 		refresh()
 	}
 }

--- a/systray_menu_unix.go
+++ b/systray_menu_unix.go
@@ -224,6 +224,34 @@ func addSeparator(id uint32, parent uint32) {
 	refresh()
 }
 
+func hideSeparator(id uint32, parent uint32) {
+	instance.menuLock.Lock()
+	defer instance.menuLock.Unlock()
+	menu, _ := findLayout(int32(parent))
+	for _, i := range menu.V2 {
+		item := i.Value().(*menuLayout)
+		if item.V0 == int32(id) {
+			item.V1["visible"] = dbus.MakeVariant(false)
+			refresh()
+			return
+		}
+	}
+}
+
+func showSeparator(id uint32, parent uint32) {
+	instance.menuLock.Lock()
+	defer instance.menuLock.Unlock()
+	menu, _ := findLayout(int32(parent))
+	for _, i := range menu.V2 {
+		item := i.Value().(*menuLayout)
+		if item.V0 == int32(id) {
+			item.V1["visible"] = dbus.MakeVariant(true)
+			refresh()
+			return
+		}
+	}
+}
+
 func applyItemToLayout(in *MenuItem, out *menuLayout) {
 	out.V1["enabled"] = dbus.MakeVariant(!in.disabled)
 	out.V1["label"] = dbus.MakeVariant(in.title)


### PR DESCRIPTION
The systray library provides a way to manage buttons. They can be shown and hidden at runtime. However, this does not apply to menu separators, which cannot be easily hidden. This leads to a situation where you can hide all buttons, but the separators are still visible, which is not a good look.

This PR aims to provide a way to manage separators with additional methods to show, hide, and remove them.



 